### PR TITLE
Refactor contraction methods into ContractionService

### DIFF
--- a/labour_service/src/labour/api/routes/contraction.py
+++ b/labour_service/src/labour/api/routes/contraction.py
@@ -16,7 +16,7 @@ from src.labour.api.schemas.requests.contraction import (
 from src.labour.api.schemas.responses.labour import (
     LabourResponse,
 )
-from src.labour.application.services.labour_service import LabourService
+from src.labour.application.services.contraction_service import ContractionService
 from src.setup.ioc.di_component_enum import ComponentEnum
 from src.user.infrastructure.auth.interfaces.controller import AuthController
 
@@ -37,7 +37,7 @@ contraction_router = APIRouter(prefix="/labour/contraction", tags=["Contractions
 @inject
 async def start_contraction(
     request_data: StartContractionRequest,
-    service: Annotated[LabourService, FromComponent(ComponentEnum.LABOUR)],
+    service: Annotated[ContractionService, FromComponent(ComponentEnum.LABOUR)],
     auth_controller: Annotated[AuthController, FromComponent(ComponentEnum.DEFAULT)],
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> LabourResponse:
@@ -65,7 +65,7 @@ async def start_contraction(
 @inject
 async def end_contraction(
     request_data: EndContractionRequest,
-    service: Annotated[LabourService, FromComponent(ComponentEnum.LABOUR)],
+    service: Annotated[ContractionService, FromComponent(ComponentEnum.LABOUR)],
     auth_controller: Annotated[AuthController, FromComponent(ComponentEnum.DEFAULT)],
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> LabourResponse:
@@ -93,7 +93,7 @@ async def end_contraction(
 @inject
 async def update_contraction(
     request_data: UpdateContractionRequest,
-    service: Annotated[LabourService, FromComponent(ComponentEnum.LABOUR)],
+    service: Annotated[ContractionService, FromComponent(ComponentEnum.LABOUR)],
     auth_controller: Annotated[AuthController, FromComponent(ComponentEnum.DEFAULT)],
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> LabourResponse:
@@ -123,7 +123,7 @@ async def update_contraction(
 @inject
 async def delete_contraction(
     request_data: DeleteContractionRequest,
-    service: Annotated[LabourService, FromComponent(ComponentEnum.LABOUR)],
+    service: Annotated[ContractionService, FromComponent(ComponentEnum.LABOUR)],
     auth_controller: Annotated[AuthController, FromComponent(ComponentEnum.DEFAULT)],
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> LabourResponse:

--- a/labour_service/src/labour/application/services/contraction_service.py
+++ b/labour_service/src/labour/application/services/contraction_service.py
@@ -1,0 +1,105 @@
+import logging
+from datetime import datetime
+from uuid import UUID
+
+from src.labour.application.dtos.labour import LabourDTO
+from src.labour.domain.contraction.exceptions import ContractionIdInvalid
+from src.labour.domain.contraction.services.delete_contraction import DeleteContractionService
+from src.labour.domain.contraction.services.end_contraction import EndContractionService
+from src.labour.domain.contraction.services.start_contraction import StartContractionService
+from src.labour.domain.contraction.services.update_contraction import UpdateContractionService
+from src.labour.domain.contraction.value_objects.contraction_id import ContractionId
+from src.labour.domain.labour.entity import Labour
+from src.labour.domain.labour.repository import LabourRepository
+from src.user.domain.exceptions import UserDoesNotHaveActiveLabour
+from src.user.domain.value_objects.user_id import UserId
+
+log = logging.getLogger(__name__)
+
+
+class ContractionService:
+    def __init__(self, labour_repository: LabourRepository):
+        self._labour_repository = labour_repository
+
+    async def _get_labour(self, birthing_person_id: str) -> Labour:
+        domain_id = UserId(birthing_person_id)
+        labour = await self._labour_repository.get_active_labour_by_birthing_person_id(domain_id)
+        if not labour:
+            raise UserDoesNotHaveActiveLabour(user_id=birthing_person_id)
+        return labour
+
+    async def start_contraction(
+        self,
+        birthing_person_id: str,
+        intensity: int | None = None,
+        start_time: datetime | None = None,
+        notes: str | None = None,
+    ) -> LabourDTO:
+        labour = await self._get_labour(birthing_person_id=birthing_person_id)
+
+        labour = StartContractionService().start_contraction(
+            labour=labour, intensity=intensity, start_time=start_time, notes=notes
+        )
+        await self._labour_repository.save(labour)
+
+        return LabourDTO.from_domain(labour)
+
+    async def end_contraction(
+        self,
+        birthing_person_id: str,
+        intensity: int,
+        end_time: datetime | None = None,
+        notes: str | None = None,
+    ) -> LabourDTO:
+        labour = await self._get_labour(birthing_person_id=birthing_person_id)
+
+        labour = EndContractionService().end_contraction(
+            labour=labour, intensity=intensity, end_time=end_time, notes=notes
+        )
+        await self._labour_repository.save(labour)
+
+        return LabourDTO.from_domain(labour)
+
+    async def update_contraction(
+        self,
+        birthing_person_id: str,
+        contraction_id: str,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        intensity: int | None = None,
+        notes: str | None = None,
+    ) -> LabourDTO:
+        labour = await self._get_labour(birthing_person_id=birthing_person_id)
+
+        try:
+            contraction_domain_id = ContractionId(UUID(contraction_id))
+        except ValueError:
+            raise ContractionIdInvalid(contraction_id=contraction_id)
+
+        labour = UpdateContractionService().update_contraction(
+            labour=labour,
+            contraction_id=contraction_domain_id,
+            start_time=start_time,
+            end_time=end_time,
+            intensity=intensity,
+            notes=notes,
+        )
+        await self._labour_repository.save(labour)
+
+        return LabourDTO.from_domain(labour)
+
+    async def delete_contraction(self, birthing_person_id: str, contraction_id: str) -> LabourDTO:
+        labour = await self._get_labour(birthing_person_id=birthing_person_id)
+
+        try:
+            contraction_domain_id = ContractionId(UUID(contraction_id))
+        except ValueError:
+            raise ContractionIdInvalid(contraction_id=contraction_id)
+
+        labour = DeleteContractionService().delete_contraction(
+            labour=labour,
+            contraction_id=contraction_domain_id,
+        )
+        await self._labour_repository.save(labour)
+
+        return LabourDTO.from_domain(labour)

--- a/labour_service/src/labour/application/services/labour_service.py
+++ b/labour_service/src/labour/application/services/labour_service.py
@@ -5,12 +5,6 @@ from uuid import UUID
 from fern_labour_core.events.producer import EventProducer
 
 from src.labour.application.dtos.labour import LabourDTO
-from src.labour.domain.contraction.exceptions import ContractionIdInvalid
-from src.labour.domain.contraction.services.delete_contraction import DeleteContractionService
-from src.labour.domain.contraction.services.end_contraction import EndContractionService
-from src.labour.domain.contraction.services.start_contraction import StartContractionService
-from src.labour.domain.contraction.services.update_contraction import UpdateContractionService
-from src.labour.domain.contraction.value_objects.contraction_id import ContractionId
 from src.labour.domain.labour.entity import Labour
 from src.labour.domain.labour.exceptions import (
     CannotDeleteActiveLabour,
@@ -108,105 +102,6 @@ class LabourService:
         labour = CompleteLabourService().complete_labour(
             labour=labour, end_time=end_time, notes=notes
         )
-        await self._labour_repository.save(labour)
-
-        await self._event_producer.publish_batch(labour.clear_domain_events())
-
-        return LabourDTO.from_domain(labour)
-
-    async def start_contraction(
-        self,
-        birthing_person_id: str,
-        intensity: int | None = None,
-        start_time: datetime | None = None,
-        notes: str | None = None,
-    ) -> LabourDTO:
-        domain_id = UserId(birthing_person_id)
-        labour = await self._labour_repository.get_active_labour_by_birthing_person_id(domain_id)
-        if not labour:
-            raise UserDoesNotHaveActiveLabour(user_id=birthing_person_id)
-
-        labour = StartContractionService().start_contraction(
-            labour=labour, intensity=intensity, start_time=start_time, notes=notes
-        )
-
-        await self._labour_repository.save(labour)
-
-        await self._event_producer.publish_batch(labour.clear_domain_events())
-
-        return LabourDTO.from_domain(labour)
-
-    async def end_contraction(
-        self,
-        birthing_person_id: str,
-        intensity: int,
-        end_time: datetime | None = None,
-        notes: str | None = None,
-    ) -> LabourDTO:
-        domain_id = UserId(birthing_person_id)
-        labour = await self._labour_repository.get_active_labour_by_birthing_person_id(domain_id)
-        if not labour:
-            raise UserDoesNotHaveActiveLabour(user_id=birthing_person_id)
-
-        labour = EndContractionService().end_contraction(
-            labour=labour, intensity=intensity, end_time=end_time, notes=notes
-        )
-        await self._labour_repository.save(labour)
-
-        await self._event_producer.publish_batch(labour.clear_domain_events())
-
-        return LabourDTO.from_domain(labour)
-
-    async def update_contraction(
-        self,
-        birthing_person_id: str,
-        contraction_id: str,
-        start_time: datetime | None = None,
-        end_time: datetime | None = None,
-        intensity: int | None = None,
-        notes: str | None = None,
-    ) -> LabourDTO:
-        domain_id = UserId(birthing_person_id)
-        labour = await self._labour_repository.get_active_labour_by_birthing_person_id(domain_id)
-        if not labour:
-            raise UserDoesNotHaveActiveLabour(user_id=birthing_person_id)
-
-        try:
-            contraction_domain_id = ContractionId(UUID(contraction_id))
-        except ValueError:
-            raise ContractionIdInvalid(contraction_id=contraction_id)
-
-        labour = UpdateContractionService().update_contraction(
-            labour=labour,
-            contraction_id=contraction_domain_id,
-            start_time=start_time,
-            end_time=end_time,
-            intensity=intensity,
-            notes=notes,
-        )
-
-        await self._labour_repository.save(labour)
-
-        await self._event_producer.publish_batch(labour.clear_domain_events())
-
-        return LabourDTO.from_domain(labour)
-
-    async def delete_contraction(self, birthing_person_id: str, contraction_id: str) -> LabourDTO:
-        domain_id = UserId(birthing_person_id)
-        labour = await self._labour_repository.get_active_labour_by_birthing_person_id(domain_id)
-        if not labour:
-            raise UserDoesNotHaveActiveLabour(user_id=birthing_person_id)
-
-        try:
-            contraction_domain_id = ContractionId(UUID(contraction_id))
-        except ValueError:
-            raise ContractionIdInvalid(contraction_id=contraction_id)
-
-        labour = DeleteContractionService().delete_contraction(
-            labour=labour,
-            contraction_id=contraction_domain_id,
-        )
-
         await self._labour_repository.save(labour)
 
         await self._event_producer.publish_batch(labour.clear_domain_events())

--- a/labour_service/src/labour/domain/contraction/services/update_contraction.py
+++ b/labour_service/src/labour/domain/contraction/services/update_contraction.py
@@ -51,7 +51,7 @@ class UpdateContractionService:
             if self._check_for_overlapping_contraction_durations(labour=labour):
                 raise ContractionsOverlappingAfterUpdate()
 
-        if intensity:
+        if intensity is not None:
             contraction.update_intensity(intensity=intensity)
 
         if notes:

--- a/labour_service/src/setup/ioc/di_providers/labour/application.py
+++ b/labour_service/src/setup/ioc/di_providers/labour/application.py
@@ -4,6 +4,7 @@ from dishka import FromComponent, Provider, Scope, provide
 from fern_labour_core.events.producer import EventProducer
 
 from src.labour.application.security.labour_authorization_service import LabourAuthorizationService
+from src.labour.application.services.contraction_service import ContractionService
 from src.labour.application.services.labour_query_service import LabourQueryService
 from src.labour.application.services.labour_service import LabourService
 from src.labour.domain.labour.repository import LabourRepository
@@ -24,6 +25,12 @@ class LabourApplicationProvider(Provider):
             labour_repository=labour_repository,
             event_producer=event_producer,
         )
+
+    @provide
+    def provide_contraction_service(
+        self, labour_repository: LabourRepository
+    ) -> ContractionService:
+        return ContractionService(labour_repository=labour_repository)
 
     @provide
     def provide_labour_query_service(

--- a/labour_service/tests/unit/app/application/conftest.py
+++ b/labour_service/tests/unit/app/application/conftest.py
@@ -7,6 +7,7 @@ from fakeredis import FakeValkey
 from src.core.infrastructure.security.rate_limiting.interface import RateLimiter
 from src.core.infrastructure.security.rate_limiting.redis import RedisRateLimiter
 from src.labour.application.security.token_generator import TokenGenerator
+from src.labour.application.services.contraction_service import ContractionService
 from src.labour.application.services.labour_query_service import LabourQueryService
 from src.labour.application.services.labour_service import LabourService
 from src.labour.domain.labour.entity import Labour
@@ -208,6 +209,13 @@ async def labour_service(
         labour_repository=labour_repo,
         event_producer=AsyncMock(),
     )
+
+
+@pytest_asyncio.fixture
+async def contraction_service(
+    labour_repo: LabourRepository,
+) -> ContractionService:
+    return ContractionService(labour_repository=labour_repo)
 
 
 @pytest_asyncio.fixture

--- a/labour_service/tests/unit/app/application/services/test_contraction_service.py
+++ b/labour_service/tests/unit/app/application/services/test_contraction_service.py
@@ -1,0 +1,159 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from src.labour.application.dtos.labour import LabourDTO
+from src.labour.application.services.contraction_service import ContractionService
+from src.labour.application.services.labour_service import LabourService
+from src.labour.domain.contraction.exceptions import ContractionIdInvalid
+from src.labour.domain.labour.enums import LabourPhase
+from src.labour.domain.labour.repository import LabourRepository
+from src.user.application.services.user_query_service import UserQueryService
+from src.user.domain.entity import User
+from src.user.domain.exceptions import (
+    UserDoesNotHaveActiveLabour,
+)
+from src.user.domain.value_objects.user_id import UserId
+
+BIRTHING_PERSON = "bp_id"
+OTHER_USER = "test_id"
+
+
+@pytest_asyncio.fixture
+def event_producer():
+    return AsyncMock()
+
+
+@pytest_asyncio.fixture
+async def contraction_service(
+    labour_repo: LabourRepository,
+    user_service: UserQueryService,
+) -> ContractionService:
+    user_service._user_repository._data = {
+        BIRTHING_PERSON: User(
+            id_=UserId(BIRTHING_PERSON),
+            username="test123",
+            first_name="Name",
+            last_name="User",
+            email="test@email.com",
+        ),
+        OTHER_USER: User(
+            id_=UserId(OTHER_USER),
+            username="abc123",
+            first_name="Test",
+            last_name="Smith",
+            email="test@smith.com",
+        ),
+    }
+    return ContractionService(labour_repository=labour_repo)
+
+
+@pytest_asyncio.fixture
+async def labour(labour_service: LabourService) -> LabourDTO:
+    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
+    return await labour_service.begin_labour(BIRTHING_PERSON)
+
+
+async def test_can_start_contraction(
+    contraction_service: ContractionService, labour: LabourDTO
+) -> None:
+    await contraction_service.start_contraction(labour.birthing_person_id)
+
+
+async def test_starting_contraction_begins_labour(
+    contraction_service: ContractionService, labour_service: LabourService
+) -> None:
+    labour = await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
+    labour = await contraction_service.start_contraction(labour.birthing_person_id)
+    assert labour.current_phase == LabourPhase.EARLY.value
+
+
+async def test_cannot_start_contraction_for_non_existent_user(
+    contraction_service: ContractionService,
+) -> None:
+    with pytest.raises(UserDoesNotHaveActiveLabour):
+        await contraction_service.start_contraction("TEST123456")
+
+
+async def test_can_end_contraction(
+    contraction_service: ContractionService, labour: LabourDTO
+) -> None:
+    await contraction_service.start_contraction(labour.birthing_person_id)
+    await contraction_service.end_contraction(labour.birthing_person_id, intensity=5)
+
+
+async def test_can_update_contraction(
+    contraction_service: ContractionService, labour: LabourDTO
+) -> None:
+    await contraction_service.start_contraction(labour.birthing_person_id)
+    labour = await contraction_service.end_contraction(labour.birthing_person_id, intensity=5)
+
+    new_start_time = datetime(2020, 1, 1, 1, 1, tzinfo=UTC)
+    new_end_time = datetime(2020, 1, 1, 1, 2, 30, tzinfo=UTC)
+
+    labour = await contraction_service.update_contraction(
+        labour.birthing_person_id,
+        labour.contractions[0].id,
+        start_time=new_start_time,
+        end_time=new_end_time,
+        intensity=2,
+        notes="test update",
+    )
+
+    contraction = labour.contractions[0]
+    assert contraction.duration == 90
+    assert contraction.intensity == 2
+    assert contraction.notes == "test update"
+    assert contraction.start_time == new_start_time
+    assert contraction.end_time == new_end_time
+
+
+async def test_cannot_update_contraction_without_labour(
+    contraction_service: ContractionService,
+) -> None:
+    with pytest.raises(UserDoesNotHaveActiveLabour):
+        await contraction_service.update_contraction(BIRTHING_PERSON, "test", intensity=2)
+
+
+async def test_cannot_update_contraction_with_invalid_id(
+    contraction_service: ContractionService, labour: LabourDTO
+) -> None:
+    with pytest.raises(ContractionIdInvalid):
+        await contraction_service.update_contraction(labour.birthing_person_id, "test", intensity=2)
+
+
+async def test_can_delete_contraction(
+    contraction_service: ContractionService, labour: LabourDTO
+) -> None:
+    await contraction_service.start_contraction(labour.birthing_person_id)
+    labour = await contraction_service.end_contraction(labour.birthing_person_id, intensity=5)
+
+    assert len(labour.contractions) == 1
+    labour = await contraction_service.delete_contraction(
+        labour.birthing_person_id,
+        labour.contractions[0].id,
+    )
+    assert len(labour.contractions) == 0
+
+
+async def test_cannot_delete_contraction_without_labour(
+    contraction_service: ContractionService,
+) -> None:
+    with pytest.raises(UserDoesNotHaveActiveLabour):
+        await contraction_service.delete_contraction(BIRTHING_PERSON, "test")
+
+
+async def test_cannot_delete_contraction_with_invalid_id(
+    contraction_service: ContractionService, labour: LabourDTO
+) -> None:
+    with pytest.raises(ContractionIdInvalid):
+        await contraction_service.delete_contraction(labour.birthing_person_id, "test")
+
+
+async def test_cannot_end_contraction_for_non_existent_user(
+    contraction_service: ContractionService,
+) -> None:
+    with pytest.raises(UserDoesNotHaveActiveLabour):
+        await contraction_service.end_contraction("TEST123456", intensity=5)

--- a/labour_service/tests/unit/app/application/services/test_labour_service.py
+++ b/labour_service/tests/unit/app/application/services/test_labour_service.py
@@ -7,9 +7,8 @@ import pytest_asyncio
 from fern_labour_core.events.producer import EventProducer
 
 from src.labour.application.dtos.labour import LabourDTO
+from src.labour.application.services.contraction_service import ContractionService
 from src.labour.application.services.labour_service import LabourService
-from src.labour.domain.contraction.exceptions import ContractionIdInvalid
-from src.labour.domain.labour.enums import LabourPhase
 from src.labour.domain.labour.exceptions import (
     CannotDeleteActiveLabour,
     InvalidLabourId,
@@ -118,105 +117,12 @@ async def test_cannot_complete_labour_for_non_existent_user(labour_service: Labo
         await labour_service.complete_labour("TEST123456")
 
 
-async def test_can_start_contraction(labour_service: LabourService) -> None:
-    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
-    await labour_service.begin_labour(BIRTHING_PERSON)
-    await labour_service.start_contraction(BIRTHING_PERSON)
-
-
-async def test_starting_contraction_begins_labour(labour_service: LabourService) -> None:
-    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
-    labour = await labour_service.start_contraction(BIRTHING_PERSON)
-    assert labour.current_phase == LabourPhase.EARLY.value
-
-
-async def test_cannot_start_contraction_for_non_existent_user(
-    labour_service: LabourService,
+async def test_can_post_labour_update(
+    labour_service: LabourService, contraction_service: ContractionService
 ) -> None:
-    with pytest.raises(UserDoesNotHaveActiveLabour):
-        await labour_service.start_contraction("TEST123456")
-
-
-async def test_can_end_contraction(labour_service: LabourService) -> None:
     await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
     await labour_service.begin_labour(BIRTHING_PERSON)
-    await labour_service.start_contraction(BIRTHING_PERSON)
-    await labour_service.end_contraction(BIRTHING_PERSON, intensity=5)
-
-
-async def test_can_update_contraction(labour_service: LabourService) -> None:
-    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
-    await labour_service.begin_labour(BIRTHING_PERSON)
-    await labour_service.start_contraction(BIRTHING_PERSON)
-    labour = await labour_service.end_contraction(BIRTHING_PERSON, intensity=5)
-
-    new_start_time = datetime(2020, 1, 1, 1, 1, tzinfo=UTC)
-    new_end_time = datetime(2020, 1, 1, 1, 2, 30, tzinfo=UTC)
-
-    labour = await labour_service.update_contraction(
-        BIRTHING_PERSON,
-        labour.contractions[0].id,
-        start_time=new_start_time,
-        end_time=new_end_time,
-        intensity=2,
-        notes="test update",
-    )
-
-    contraction = labour.contractions[0]
-    assert contraction.duration == 90
-    assert contraction.intensity == 2
-    assert contraction.notes == "test update"
-    assert contraction.start_time == new_start_time
-    assert contraction.end_time == new_end_time
-
-
-async def test_cannot_update_contraction_without_labour(labour_service: LabourService) -> None:
-    with pytest.raises(UserDoesNotHaveActiveLabour):
-        await labour_service.update_contraction(BIRTHING_PERSON, "test", intensity=2)
-
-
-async def test_cannot_update_contraction_with_invalid_id(labour_service: LabourService) -> None:
-    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
-    await labour_service.begin_labour(BIRTHING_PERSON)
-    with pytest.raises(ContractionIdInvalid):
-        await labour_service.update_contraction(BIRTHING_PERSON, "test", intensity=2)
-
-
-async def test_can_delete_contraction(labour_service: LabourService) -> None:
-    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
-    await labour_service.begin_labour(BIRTHING_PERSON)
-    await labour_service.start_contraction(BIRTHING_PERSON)
-    labour = await labour_service.end_contraction(BIRTHING_PERSON, intensity=5)
-
-    assert len(labour.contractions) == 1
-    labour = await labour_service.delete_contraction(
-        BIRTHING_PERSON,
-        labour.contractions[0].id,
-    )
-    assert len(labour.contractions) == 0
-
-
-async def test_cannot_delete_contraction_without_labour(labour_service: LabourService) -> None:
-    with pytest.raises(UserDoesNotHaveActiveLabour):
-        await labour_service.delete_contraction(BIRTHING_PERSON, "test")
-
-
-async def test_cannot_delete_contraction_with_invalid_id(labour_service: LabourService) -> None:
-    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
-    await labour_service.begin_labour(BIRTHING_PERSON)
-    with pytest.raises(ContractionIdInvalid):
-        await labour_service.delete_contraction(BIRTHING_PERSON, "test")
-
-
-async def test_cannot_end_contraction_for_non_existent_user(labour_service: LabourService) -> None:
-    with pytest.raises(UserDoesNotHaveActiveLabour):
-        await labour_service.end_contraction("TEST123456", intensity=5)
-
-
-async def test_can_post_labour_update(labour_service: LabourService) -> None:
-    await labour_service.plan_labour(BIRTHING_PERSON, True, datetime.now(UTC))
-    await labour_service.begin_labour(BIRTHING_PERSON)
-    await labour_service.start_contraction(BIRTHING_PERSON)
+    await contraction_service.start_contraction(BIRTHING_PERSON)
     await labour_service.post_labour_update(
         BIRTHING_PERSON, labour_update_type="announcement", message="Test message"
     )

--- a/labour_service/tests/unit/app/domain/services/test_update_contraction.py
+++ b/labour_service/tests/unit/app/domain/services/test_update_contraction.py
@@ -60,6 +60,25 @@ def test_can_update_contraction_intensity(sample_labour: Labour):
     assert labour.contractions[0].intensity == 2
 
 
+def test_can_update_contraction_intensity_to_zero(sample_labour: Labour):
+    labour = BeginLabourService().begin_labour(sample_labour)
+    contraction_start_time = datetime(2020, 1, 1, 1, 0)
+    contraction_end_time = datetime(2020, 1, 1, 1, 1)
+    StartContractionService().start_contraction(
+        labour=sample_labour,
+        start_time=contraction_start_time,
+    )
+    EndContractionService().end_contraction(
+        labour=sample_labour,
+        intensity=5,
+        end_time=contraction_end_time,
+    )
+    UpdateContractionService().update_contraction(
+        labour=sample_labour, contraction_id=labour.contractions[0].id_, intensity=0
+    )
+    assert labour.contractions[0].intensity == 0
+
+
 def test_cannot_update_contraction_intensity_invalid(sample_labour: Labour):
     labour = BeginLabourService().begin_labour(sample_labour)
     contraction_start_time = datetime(2020, 1, 1, 1, 0)

--- a/labour_service/tests/unit/app/presentation/api/conftest.py
+++ b/labour_service/tests/unit/app/presentation/api/conftest.py
@@ -23,6 +23,7 @@ from src.core.infrastructure.security.request_verification.interface import (
 )
 from src.labour.application.dtos.labour import LabourDTO
 from src.labour.application.security.labour_authorization_service import LabourAuthorizationService
+from src.labour.application.services.contraction_service import ContractionService
 from src.labour.application.services.labour_query_service import LabourQueryService
 from src.labour.application.services.labour_service import LabourService
 from src.payments.infrastructure.stripe.stripe_payment_service import StripePaymentService
@@ -289,6 +290,13 @@ class MockLabourProvider(Provider):
         service.plan_labour.return_value = mock_labour_dto
         service.update_labour_plan.return_value = mock_labour_dto
         service.begin_labour.return_value = mock_labour_dto
+        return service
+
+    @provide()
+    def get_contraction_service(self) -> ContractionService:
+        """Create a mock contraction service."""
+        service = MagicMock(spec=ContractionService)
+        mock_labour_dto = self.get_mock_labour_dto()
         service.start_contraction.return_value = mock_labour_dto
         service.end_contraction.return_value = mock_labour_dto
         return service


### PR DESCRIPTION
Also:
- Stop producing contraction events. If the event producer is down then we don't want contraction tracking to be effected.
- Fix being unable to set contraction intensity to 0.